### PR TITLE
Allow more characters in tags

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -52,7 +52,7 @@ module.exports = grammar({
     docstring_content: ($) => repeat1($.docstring_line),
     docstring_line: ($) => /.+/,
 
-    tag: ($) => /\s*@[a-zA-z-_0-9]+/,
+    tag: ($) => /\s*@[^@\s]+/,
     _tags: ($) => repeat1($.tag),
 
     section_keyword: ($) => /[\w ]+:/,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -371,7 +371,7 @@
     },
     "tag": {
       "type": "PATTERN",
-      "value": "\\s*@[a-zA-z-_0-9]+"
+      "value": "\\s*@[^@\\s]+"
     },
     "_tags": {
       "type": "REPEAT1",
@@ -506,4 +506,3 @@
   "inline": [],
   "supertypes": []
 }
-


### PR DESCRIPTION
Regular expression for tags appears to be too restrictive which causes is to highlight syntax incorrectly for valid tag values, e. g. `@foo.bar`.
I've ported a regular expression from a relatively popular VSCode Cucumber/Gherkin extension. It essentially allows anything except whitespaces in tags.